### PR TITLE
Fix the global access to the overridden font

### DIFF
--- a/src/listbox.moon
+++ b/src/listbox.moon
@@ -20,7 +20,7 @@ create_listbox = =>
 	dispatch "pause"
 	font_height = (text) ->
 		_, count = string.gsub(remove_color(text), "\n", "\n")
-		return math.max(text_font\getHeight! * (1 + count), @media)
+		return math.max(love.text_font\getHeight! * (1 + count), @media)
 	close = ->
 		input_event\remove!
 		draw_event\remove!
@@ -47,8 +47,8 @@ create_listbox = =>
 			if chosen.left then chosen.left(chosen)
 		return false
 	draw_event = on "draw_choice", ->
-		lg.setFont(text_font)
-		w = 3 * pad + _.max([text_font\getWidth(remove_color(c.text)) for c in *@choices]) + @media
+		lg.setFont(love.text_font)
+		w = 3 * pad + _.max([love.text_font\getWidth(remove_color(c.text)) for c in *@choices]) + @media
 		h, y_selected = pad, 0
 		for i, c in ipairs @choices
 			h += font_height(c.text) + pad

--- a/src/main.moon
+++ b/src/main.moon
@@ -30,7 +30,7 @@ original_width, original_height = lg.getWidth!,lg.getHeight!
 -- 		love.filesystem.write('profile.txt', profile.report(40))
 
 font = nil
-text_font = nil
+love.text_font = nil
 love.resize = (w, h) ->
 	sx, sy = w / original_width, h / original_height
 	px, py = w/256, h/192 --resolution of the DS
@@ -38,7 +38,7 @@ love.resize = (w, h) ->
 	if w < 600 then font_size = 20
 	lg.setNewFont(font_size)
 	font = lg.getFont!
-	text_font = font
+	if love.text_font == nil then love.text_font = font
 	dispatch "resize", {:sx, :sy, :px, :py}
 next_msg = (ins) ->
 	if ins == nil

--- a/src/text/text.moon
+++ b/src/text/text.moon
@@ -9,7 +9,7 @@ override_font = nil
 update_font = ->
 	if interpreter and not override_font
 		font_path = interpreter.base_dir.."default.ttf"
-        if lfs.getInfo(font_path) then love.text_font = lg.newFont(font_path, 32)
+		if lfs.getInfo(font_path) then love.text_font = lg.newFont(font_path, 32)
 	else love.text_font = font
 on "config", =>
 	override_font = @font.override_font

--- a/src/text/text.moon
+++ b/src/text/text.moon
@@ -9,8 +9,8 @@ override_font = nil
 update_font = ->
 	if interpreter and not override_font
 		font_path = interpreter.base_dir.."default.ttf"
-		if lfs.getInfo(font_path) then text_font = lg.newFont(font_path, 32)
-	else text_font = font
+        if lfs.getInfo(font_path) then love.text_font = lg.newFont(font_path, 32)
+	else love.text_font = font
 on "config", =>
 	override_font = @font.override_font
 	update_font!
@@ -92,8 +92,8 @@ on "input", =>
 	return false
 on "draw_text", ->
 	if #buffer > 0
-		lg.setFont(text_font)
-		w, h = lg.getWidth! - 2*pad, pad + (text_font\getHeight! + pad) * lines
+		lg.setFont(love.text_font)
+		w, h = lg.getWidth! - 2*pad, pad + (love.text_font\getHeight! + pad) * lines
 		x, y = pad, lg.getHeight! - h - pad
 		lg.setColor(.18,.204,.251, .8)
 		lg.rectangle("fill", x, y, w, h)
@@ -102,7 +102,7 @@ on "draw_text", ->
 		draw_buffer = _.first(buffer, lines)
 		for line in *draw_buffer
 			lg.print(line, 2*pad, y_pos)
-			y_pos += text_font\getHeight! + pad
+			y_pos += love.text_font\getHeight! + pad
 		lg.setFont(font)
 word_wrap = (text, max_width) ->
 	-- Come up with a way to handle a single word that is longer than the width
@@ -119,7 +119,7 @@ word_wrap = (text, max_width) ->
 			last_color = colored[i-1]
 			for j=2, #words
 				tmp = line.." "..words[j]
-				if text_font\getWidth(tmp) > max_width
+				if love.text_font\getWidth(tmp) > max_width
 					table.insert(list[l], last_color)
 					table.insert(list[l], line)
 					l += 1


### PR DESCRIPTION
Sorry. The previous bugfix does not seem to fix the original issue, as Moonscript has restrictions on global vars definitions. Since I had struggles to compile and run the project on Windows 11 (extremely awkward installation process for Luarocks and dependencies of the correct versions), eventually I had to get Linux and compile there. The fix is probably not the best example of behaving with globals, but it does its job. Please feel free to make it prettier.

![image](https://user-images.githubusercontent.com/493209/218698696-c9eefa4a-eb8d-4b2c-bcf0-51cfb37f2245.png)
