### PR TITLE
fix variable replacement

### DIFF
--- a/src/script.moon
+++ b/src/script.moon
@@ -29,6 +29,8 @@ read_file = (s, script_file) ->
 	labels = {ins.label, i for i, ins in ipairs ins when ins.type == "label" }
 	{:file, :ins, :labels, n: 1}
 interpolate = (s, text) ->
+	for var in text\gmatch("{$([^}]*)}")
+		text = text\gsub("{$"..escape_pattern(var).."}", tostring(mem(s, var)[var]))	
 	for var in text\gmatch("$(%S*)")
 		text = text\gsub("$"..escape_pattern(var), tostring(mem(s, var)[var]))
 	return text


### PR DESCRIPTION
The weeaboo.nl converter for Never7 uses variables to display the in-game time, like this:
![TANhDH9](https://user-images.githubusercontent.com/12817318/228032925-e8ad75fa-d33e-405a-b06b-7589d0b6027a.jpeg)

This appears properly because vnds's parser specifically handles variables surrounded by {}. VNDS-LOVE fails on this:
![VNDS-LOVE broken time display](https://user-images.githubusercontent.com/12817318/228033406-91ee8ee6-3182-414e-b7cb-7d2afd003dc0.png)

This pull request should fix VNDS-LOVE so that it properly matches the intended behavior.

