### PR TITLE
Fix going through custom IF comparison ops

### DIFF
--- a/src/script.moon
+++ b/src/script.moon
@@ -68,6 +68,8 @@ next_instruction = (s) ->
 			lhs = MEM[ins.var] or 0 --default to 0
 			rhs = ins.value.literal or MEM[ins.value.var] or 0
 			if not ops[ins.modifier] or not ops[ins.modifier](lhs, rhs)
+                               if not ops[ins.modifier]
+                                       pprint "Unknown op '"..ins.modifier.."' at "..s.file..":"..s.n
 				count = 1
 				while count > 0
 					s.n += 1

--- a/src/script.moon
+++ b/src/script.moon
@@ -67,7 +67,7 @@ next_instruction = (s) ->
 		when "if"
 			lhs = MEM[ins.var] or 0 --default to 0
 			rhs = ins.value.literal or MEM[ins.value.var] or 0
-			if not ops[ins.modifier](lhs, rhs)
+			if not ops[ins.modifier] or not ops[ins.modifier](lhs, rhs)
 				count = 1
 				while count > 0
 					s.n += 1


### PR DESCRIPTION
Ever 17, s_2a.scr:48.
```
if v_26 0a28 0
	goto L000000ae
fi
```
This has most probably been left for the debugging purposes. The original VNDS engine does not crash, while passing through this, so I assume the behaviour of ignoring unknown / undocumented ops is legit.