### PR TITLE
Fix setting vars from another var in a choice loop

### DIFF
--- a/src/script.moon
+++ b/src/script.moon
@@ -60,13 +60,13 @@ next_instruction = (s) ->
 			return s, ins
 		when "setvar", "gsetvar"
 			MEM = mem_type(s, ins.type)
-			ins.value.literal = MEM[ins.value.var] or ins.value.literal or 0
+			ins.value.literal = mem(s, ins.value.var)[ins.value.var] or ins.value.literal or 0
 			MEM[ins.var] = ops[ins.modifier](ins.value.literal, MEM[ins.var])
 			if ins.modifer ==  "~" then MEM = {}
 		when "random" then MEM[ins.var] = math.random(ins.low, ins.high)
 		when "if"
 			lhs = MEM[ins.var] or 0 --default to 0
-			rhs = ins.value.literal or MEM[ins.value.var] or 0
+			rhs = mem(s, ins.value.var)[ins.value.var] or ins.value.literal or 0
 			if not ops[ins.modifier](lhs, rhs)
 				count = 1
 				while count > 0

--- a/src/script.moon
+++ b/src/script.moon
@@ -60,7 +60,7 @@ next_instruction = (s) ->
 			return s, ins
 		when "setvar", "gsetvar"
 			MEM = mem_type(s, ins.type)
-			ins.value.literal = ins.value.literal or MEM[ins.value.var] or 0
+			ins.value.literal = MEM[ins.value.var] or ins.value.literal or 0
 			MEM[ins.var] = ops[ins.modifier](ins.value.literal, MEM[ins.var])
 			if ins.modifer ==  "~" then MEM = {}
 		when "random" then MEM[ins.var] = math.random(ins.low, ins.high)


### PR DESCRIPTION
Ever 17, s_1c.scr:1015
```
setvar v_b3 = selected2
```
The `v_b3` variable is reused in a choice loop, that happens above. If it already has the literal value set, the referenced value (from `selected2`) is ignored, which makes the following choices unreachable.