### PR TITLE
Fix overridden font on Linux

### DIFF
--- a/src/text/text.moon
+++ b/src/text/text.moon
@@ -14,6 +14,7 @@ update_font = ->
 on "config", =>
 	override_font = @font.override_font
 	update_font!
+on "resize", -> update_font!
 on "restore", ->
 	update_font!
 	buffer = {} --clear text state when restoring


### PR DESCRIPTION
**The problem**: On Linux, window resize events happen during startup/loading, which triggers a reset to the default system font. If the system font doesn't support Cyrillic, text turns into squares even if `default.ttf` is present in the novel folder.

**The fix**: I've added an on "resize", update_font listener to ensure the novel-specific font is reapplied whenever the window is resized. This completely resolves the issue on Debian.
